### PR TITLE
Improve README with protocol details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,68 @@
-Getting started with the project
---------------------------------
+# Storage File Server
 
-### Prerequisites
-- Min.IO server
-- MySQL server
-- Docker
-- Docker-compose
-- Node.js
-- NPM
+A Node.js server that exposes a simple HTTP API for storing metadata in MySQL and uploading files to an S3 compatible service (tested with MinIO). It includes basic user management and a single endpoint for uploading file data using a session token.
 
-### Installation
+## Prerequisites
+- Node.js and npm
+- MySQL database
+- MinIO or other S3 compatible storage
+- Docker and docker-compose (optional, for local infrastructure)
+
+## Installation
+
 1. Clone the repository
-2. Run `npm install` to install the dependencies
-3. Create a `.env` file in the root directory and add the following environment variables:
+2. Run `npm install`
+3. Create a `.env` file in the project root with at least:
     ```
     DB_HOST=localhost
     DB_USER=root
     DB_PASSWORD=root
     DB_NAME=storage
-    AWS_ACCESS_KEY_ID=uZnZVQ9ZZiL08tF6fEKj
-    AWS_SECRET_ACCESS_KEY=yZ6LwRC9J1wr9vvoAG7Tuf3z2KITSCTc6dSwFovf
+    AWS_ACCESS_KEY_ID=<access-key>
+    AWS_SECRET_ACCESS_KEY=<secret-key>
     MINIO_ENDPOINT=http://localhost:9000
     AWS_BUCKET_NAME=storage
     PORT=3500
     ```
-4. Start up the docker compose files at https://github.com/Rich43/storage-docker/tree/main
-5. Run `npm start` to start the server
+4. Start up the database and MinIO containers (the [storage-docker](https://github.com/Rich43/storage-docker/tree/main) repository contains compose files).
+5. Run `npm start` to start the server.
+
+## API protocol
+
+### User endpoints
+
+`GET /users`  
+Return a JSON array of users.
+
+`POST /users`  
+Create a user. The request body is JSON representing the user fields stored in the `user` table.
+
+### Media upload
+
+`POST /media/upload`  
+Upload raw file data directly to the configured S3 bucket. The request body must be JSON with the following fields:
+
+```json
+{
+  "sessionToken": "string",
+  "mediaId": 123,
+  "fileContent": "Base64 encoded content",
+  "mimeType": "image/png"
+}
+```
+
+The server verifies that `sessionToken` exists in the `session` table and that `mediaId` refers to a row in the `media` table. On success, the file is uploaded to S3 at the path stored in `media.url` and the resulting S3 upload response is returned.
+
+### Response Example
+```json
+{
+  "Location": "http://localhost:9000/storage/path/file.png",
+  "Bucket": "storage",
+  "Key": "path/file.png",
+  "ETag": "\"abc123\""
+}
+```
+
+## Development
+
+The default port is `3500` (overridable via the `PORT` env variable). Code changes are reloaded automatically through `nodemon`.


### PR DESCRIPTION
## Summary
- expand README with environment setup instructions
- document API usage and protocol details for user and media upload endpoints

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878c948010c832983e5b76ba9e2469a