### PR TITLE
Implement file download and delete endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ The server verifies that `sessionToken` exists in the `session` table and that `
 }
 ```
 
+### Additional media endpoints
+
+`GET /media/:id/download`
+: Download the raw file associated with a media record.
+
+`DELETE /media/:id`
+: Remove the file from S3.
+
+`GET /media/:id/metadata`
+: Retrieve metadata from the database and S3.
+
 ## Development
 
 The default port is `3500` (overridable via the `PORT` env variable). Code changes are reloaded automatically through `nodemon`.

--- a/controllers/mediaController.js
+++ b/controllers/mediaController.js
@@ -1,6 +1,6 @@
 import Session from '../models/session.js';
 import Media from '../models/media.js';
-import { uploadFile } from '../utils/s3.js';
+import { uploadFile, downloadFile, deleteFile, getFileMetadata } from '../utils/s3.js';
 
 const mediaController = {
     async uploadMedia(req, res) {
@@ -25,6 +25,46 @@ const mediaController = {
             res.status(201).json(result);
         } catch (error) {
             res.status(500).json({ error: 'Failed to upload file' });
+        }
+    },
+    async downloadMedia(req, res) {
+        const { id } = req.params;
+        try {
+            const media = await Media.getById(id);
+            if (!media) {
+                return res.status(404).json({ error: 'Media not found' });
+            }
+            const file = await downloadFile(media.url);
+            res.set('Content-Type', file.ContentType);
+            res.send(file.Body);
+        } catch (error) {
+            res.status(500).json({ error: 'Failed to download file' });
+        }
+    },
+    async deleteMedia(req, res) {
+        const { id } = req.params;
+        try {
+            const media = await Media.getById(id);
+            if (!media) {
+                return res.status(404).json({ error: 'Media not found' });
+            }
+            await deleteFile(media.url);
+            res.status(204).send();
+        } catch (error) {
+            res.status(500).json({ error: 'Failed to delete file' });
+        }
+    },
+    async getMediaMetadata(req, res) {
+        const { id } = req.params;
+        try {
+            const media = await Media.getById(id);
+            if (!media) {
+                return res.status(404).json({ error: 'Media not found' });
+            }
+            const meta = await getFileMetadata(media.url);
+            res.json({ db: media, s3: meta });
+        } catch (error) {
+            res.status(500).json({ error: 'Failed to retrieve metadata' });
         }
     },
     // Add more methods as needed

--- a/routes/mediaRoutes.js
+++ b/routes/mediaRoutes.js
@@ -4,6 +4,10 @@ import mediaController from '../controllers/mediaController.js';
 const router = Router();
 
 router.post('/upload', mediaController.uploadMedia);
+router.get('/:id/download', mediaController.downloadMedia);
+router.delete('/:id', mediaController.deleteMedia);
+router.get('/:id/metadata', mediaController.getMediaMetadata);
 // Add more routes as needed
 
 export default router;
+

--- a/utils/s3.js
+++ b/utils/s3.js
@@ -1,0 +1,46 @@
+import AWS from 'aws-sdk';
+
+const s3 = new AWS.S3({
+    endpoint: process.env.MINIO_ENDPOINT,
+    s3ForcePathStyle: true,
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+});
+
+const bucket = process.env.AWS_BUCKET_NAME;
+
+export function uploadFile(fileContent, key, mimeType) {
+    const buffer = Buffer.from(fileContent, 'base64');
+    const params = {
+        Bucket: bucket,
+        Key: key,
+        Body: buffer,
+        ContentType: mimeType,
+    };
+    return s3.upload(params).promise();
+}
+
+export function downloadFile(key) {
+    const params = {
+        Bucket: bucket,
+        Key: key,
+    };
+    return s3.getObject(params).promise();
+}
+
+export function deleteFile(key) {
+    const params = {
+        Bucket: bucket,
+        Key: key,
+    };
+    return s3.deleteObject(params).promise();
+}
+
+export function getFileMetadata(key) {
+    const params = {
+        Bucket: bucket,
+        Key: key,
+    };
+    return s3.headObject(params).promise();
+}
+


### PR DESCRIPTION
## Summary
- add S3 utility helper for upload, download and delete
- expose media download, delete and metadata endpoints
- document new media endpoints in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687933099bbc832996ea1c636c405ff1