### PR TITLE
Add unit tests for controllers and S3 utilities

### DIFF
--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'assert';
+import {mock} from 'node:test';
+import AWS from 'aws-sdk';
+
+function restoreAll(...mocks) {
+  for (const m of mocks) m.mock.restore();
+}
+
+test('uploadFile uses S3 upload with correct params', async () => {
+  process.env.AWS_BUCKET_NAME = 'bucket';
+  const expected = { Location: 'url' };
+  const uploadStub = mock.method(AWS.S3.prototype, 'upload', () => {
+    return { promise: () => Promise.resolve(expected) };
+  });
+  const { uploadFile } = await import('../utils/s3.js?case=upload');
+  const result = await uploadFile('ZmFrZQ==', 'path/file.txt', 'text/plain');
+  assert.deepStrictEqual(result, expected);
+  assert.strictEqual(uploadStub.mock.callCount(), 1);
+  assert.deepStrictEqual(uploadStub.mock.calls[0].arguments[0], {
+    Bucket: 'bucket',
+    Key: 'path/file.txt',
+    Body: Buffer.from('ZmFrZQ==', 'base64'),
+    ContentType: 'text/plain'
+  });
+  restoreAll(uploadStub);
+});
+
+test('downloadFile uses S3 getObject', async () => {
+  process.env.AWS_BUCKET_NAME = 'bucket';
+  const expected = { Body: Buffer.from('a'), ContentType: 'text/plain' };
+  const ctorStub = mock.method(AWS, 'S3', function () { return {
+    getObject(params) {
+      return { promise: () => Promise.resolve(expected), params };
+    }
+  }; });
+  const { downloadFile } = await import('../utils/s3.js?case=download');
+  const result = await downloadFile('path/file.txt');
+  assert.deepStrictEqual(result, expected);
+  assert.strictEqual(ctorStub.mock.callCount(), 1);
+  restoreAll(ctorStub);
+});

--- a/test/userController.test.js
+++ b/test/userController.test.js
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'assert';
+import {mock} from 'node:test';
+import userController from '../controllers/userController.js';
+import User from '../models/user.js';
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; }
+  };
+}
+
+// success case for getAllUsers
+
+test('userController.getAllUsers returns list of users', async () => {
+  const users = [{id:1, name:'Alice'}];
+  const stub = mock.method(User, 'getAll', async () => users);
+  const req = {};
+  const res = createRes();
+  await userController.getAllUsers(req, res);
+  assert.strictEqual(res.statusCode, 200);
+  assert.deepStrictEqual(res.body, users);
+  assert.strictEqual(stub.mock.callCount(), 1);
+  stub.mock.restore();
+});
+
+// error case for getAllUsers
+
+test('userController.getAllUsers handles errors', async () => {
+  const err = new Error('db failed');
+  const stub = mock.method(User, 'getAll', async () => { throw err; });
+  const req = {};
+  const res = createRes();
+  await userController.getAllUsers(req, res);
+  assert.strictEqual(res.statusCode, 500);
+  assert.deepStrictEqual(res.body, { error: 'Failed to retrieve users' });
+  assert.strictEqual(stub.mock.callCount(), 1);
+  stub.mock.restore();
+});
+
+// success case for createUser
+
+test('userController.createUser creates user', async () => {
+  const newUser = {id:2, name:'Bob'};
+  const stub = mock.method(User, 'create', async (body) => { assert.deepStrictEqual(body, newUser); return newUser; });
+  const req = { body: newUser };
+  const res = createRes();
+  await userController.createUser(req, res);
+  assert.strictEqual(res.statusCode, 201);
+  assert.deepStrictEqual(res.body, newUser);
+  assert.strictEqual(stub.mock.callCount(), 1);
+  stub.mock.restore();
+});
+
+// error case for createUser
+
+test('userController.createUser handles errors', async () => {
+  const stub = mock.method(User, 'create', async () => { throw new Error('fail'); });
+  const req = { body: {name:'Bad'} };
+  const res = createRes();
+  await userController.createUser(req, res);
+  assert.strictEqual(res.statusCode, 500);
+  assert.deepStrictEqual(res.body, { error: 'Failed to create user' });
+  assert.strictEqual(stub.mock.callCount(), 1);
+  stub.mock.restore();
+});


### PR DESCRIPTION
## Summary
- add tests for user controller
- add tests for S3 upload/download utilities

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a7269e6688329a6fbebf894511273