### PR TITLE
Fix user creation output and default port

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -7,8 +7,9 @@ const User = {
     getById(id) {
         return knex('user').where({ id }).first();
     },
-    create(user) {
-        return knex('user').insert(user);
+    async create(user) {
+        const [id] = await knex('user').insert(user);
+        return User.getById(id);
     },
     // Add more methods as needed
 };

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ app.use(bodyParser.json());
 app.use('/users', userRoutes);
 app.use('/media', mediaRoutes); // Add media routes
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 3500;
 
 app.listen(PORT, () => {
     console.log(`Server is running on port ${PORT}`);


### PR DESCRIPTION
## Summary
- return inserted user object from User model
- listen on port 3500 by default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a7bb25b2483298ab3aaac30953ebc